### PR TITLE
Add primary Greek Unicode range

### DIFF
--- a/webfonts/pankosmia-Cardo.css
+++ b/webfonts/pankosmia-Cardo.css
@@ -7,7 +7,7 @@
   font-style: normal;
   font-weight: normal; /* 400 Normal (Regular) */
   src: url(./cardo/Cardo-Regular.woff2);
-  unicode-range: U+1F00-1FFF, U+10140-1018F;
+  unicode-range: U+0370-03FF, U+1F00-1FFF, U+10140-1018F;
   font-display: swap;
 }
 
@@ -17,7 +17,7 @@
   font-style: italic;
   font-weight: normal; /* 400 Normal (Regular) */
   src: url(./cardo/Cardo-Italic.woff2);
-  unicode-range: U+1F00-1FFF, U+10140-1018F;
+  unicode-range: U+0370-03FF, U+1F00-1FFF, U+10140-1018F;
   font-display: swap;
 }
 
@@ -27,7 +27,7 @@
   font-style: normal;
   font-weight: bold; /* 700 */
   src: url(./cardo/Cardo-Bold.woff2);
-  unicode-range: U+1F00-1FFF, U+10140-1018F;
+  unicode-range: U+0370-03FF, U+1F00-1FFF, U+10140-1018F;
   font-display: swap;
 }
 
@@ -37,6 +37,6 @@
   font-style: italic;
   font-weight: bold; /* 700 */
   src: url(./cardo/Cardo-Bold.woff2);
-  unicode-range: U+1F00-1FFF, U+10140-1018F;
+  unicode-range: U+0370-03FF, U+1F00-1FFF, U+10140-1018F;
   font-display: swap;
 }


### PR DESCRIPTION
This adds the primary Greek script Unicode range, previously missed when Greek Extended and Ancient Greek Numbers were added.

Notes:
- When testing delete ~\pankosmia_working\webfonts and let pithekos reload them.
- There is no need to bump the crate version as this file is not included.