### PR TITLE
Add U+0020 (space) to Awami, and reflect punctuation reality

### DIFF
--- a/webfonts/pankosmia-Awami_Nastaliq.css
+++ b/webfonts/pankosmia-Awami_Nastaliq.css
@@ -9,7 +9,7 @@
     font-style: normal;
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
@@ -22,7 +22,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
@@ -35,7 +35,7 @@
     font-style: normal;
     font-weight: bold; /* 700 */
     src: url(./awami/AwamiNastaliq-Bold.woff2);
-    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
@@ -48,7 +48,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: bold; /* 700 */
     src: url(./awami/AwamiNastaliq-Bold.woff2);
-    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
     -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;

--- a/webfonts/pankosmia-Awami_Nastaliq.css
+++ b/webfonts/pankosmia-Awami_Nastaliq.css
@@ -11,9 +11,9 @@
     src: url(./awami/AwamiNastaliq-Regular.woff2);
     unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
+    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
+    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
+    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
   }
 
   /* italic */
@@ -24,9 +24,9 @@
     src: url(./awami/AwamiNastaliq-Regular.woff2);
     unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
+    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
+    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
+    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
   }
 
   /* bold */
@@ -37,9 +37,9 @@
     src: url(./awami/AwamiNastaliq-Bold.woff2);
     unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
+    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
+    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
+    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
   }
 
   /* bold italic*/
@@ -50,8 +50,8 @@
     src: url(./awami/AwamiNastaliq-Bold.woff2);
     unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
-    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
-    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
-    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, "punc" 0;
+    font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
+    -moz-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
+    -webkit-font-feature-settings: "hehk" 0, "hedo" 1, "lamv" 0, "cv85" 0, "cv78" 1, "hamz" 0, "wdsp" 2, "agca" 3, "shrt" 2, ""punc" 2;
   }
 }


### PR DESCRIPTION
### This PR:
- Adds U+0020 (space) to Awami Nastaliq.  It is needed for the "word spacing" font-feature-settings options.
- Sets all Awami Nastaliq font variations to "punc 2", as our unicode ranges force it to this (Latin).

### Note: 
- U+0200 (space) would only be needed in panksomia-web if someone were to edit the "wdsp" option in the css.
- The "punc 2" just matches our current reality; A 0 or 1 won't have an effect without adjusting the unicode range.