### PR TITLE
windows - cmake v3 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cargo run # Creates a pankosmia_working directory at the root of the user direct
 - npm 10.7.0
 - node 18.20.4
 - rustc 1.83.0 -- See https://www.rust-lang.org/tools/install
-- cmake 3.31.0 -- See https://cmake.org/download/
+- cmake 3.31.0 -- _Version 3 is required._ See https://cmake.org/download/
 
 ## Using within Tauri
 See the Pithekos repo for example code.


### PR DESCRIPTION
Added readme clarification that for Windows version ̌3 of cmake is required:

![image](https://github.com/user-attachments/assets/4ab54746-60eb-4c11-97a5-da329655fcaf)
