### PR TITLE
Add Remaining Font Feature Settings

### DIFF
--- a/templates/user_settings.json
+++ b/templates/user_settings.json
@@ -9,6 +9,346 @@
     "font_set": "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus",
     "size": "medium",
     "features": {
+      "Andika": [
+        {
+          "key": "smcp",
+          "value": 0
+        },
+        {
+          "key": "c2sc",
+          "value": 0
+        },
+        {
+          "key": "ss01",
+          "value": 0
+        },
+        {
+          "key": "ss13",
+          "value": 0
+        },
+        {
+          "key": "ss14",
+          "value": 0
+        },
+        {
+          "key": "ss04",
+          "value": 0
+        },
+        {
+          "key": "ss05",
+          "value": 0
+        },
+        {
+          "key": "cv13",
+          "value": 0
+        },
+        {
+          "key": "cv17",
+          "value": 0
+        },
+        {
+          "key": "cv28",
+          "value": 0
+        },
+        {
+          "key": "cv31",
+          "value": 0
+        },
+        {
+          "key": "cv35",
+          "value": 0
+        },
+        {
+          "key": "cv37",
+          "value": 0
+        },
+        {
+          "key": "cv39",
+          "value": 0
+        },
+        {
+          "key": "cv43",
+          "value": 0
+        },
+        {
+          "key": "cv44",
+          "value": 0
+        },
+        {
+          "key": "cv46",
+          "value": 0
+        },
+        {
+          "key": "cv47",
+          "value": 0
+        },
+        {
+          "key": "cv49",
+          "value": 0
+        },
+        {
+          "key": "cv52",
+          "value": 0
+        },
+        {
+          "key": "cv51",
+          "value": 0
+        },
+        {
+          "key": "cv55",
+          "value": 0
+        },
+        {
+          "key": "cv56",
+          "value": 0
+        },
+        {
+          "key": "cv57",
+          "value": 0
+        },
+        {
+          "key": "cv62",
+          "value": 0
+        },
+        {
+          "key": "cv68",
+          "value": 0
+        },
+        {
+          "key": "cv67",
+          "value": 0
+        },
+        {
+          "key": "cv20",
+          "value": 0
+        },
+        {
+          "key": "cv19",
+          "value": 0
+        },
+        {
+          "key": "cv25",
+          "value": 0
+        },
+        {
+          "key": "cv69",
+          "value": 0
+        },
+        {
+          "key": "cv75",
+          "value": 0
+        },
+        {
+          "key": "cv79",
+          "value": 0
+        },
+        {
+          "key": "cv76",
+          "value": 0
+        },
+        {
+          "key": "cv77",
+          "value": 0
+        },
+        {
+          "key": "cv70",
+          "value": 0
+        },
+        {
+          "key": "cv71",
+          "value": 0
+        },
+        {
+          "key": "cv98",
+          "value": 0
+        },
+        {
+          "key": "cv80",
+          "value": 0
+        },
+        {
+          "key": "cv81",
+          "value": 0
+        },
+        {
+          "key": "cv82",
+          "value": 0
+        },
+        {
+          "key": "cv84",
+          "value": 0
+        },
+        {
+          "key": "cv90",
+          "value": 0
+        },
+        {
+          "key": "cv91",
+          "value": 0
+        },
+        {
+          "key": "cv92",
+          "value": 0
+        },
+        {
+          "key": "subs",
+          "value": 0
+        },
+        {
+          "key": "sups",
+          "value": 0
+        },
+        {
+          "key": "frac",
+          "value": 0
+        },
+        {
+          "key": "cv10",
+          "value": 0
+        },
+        {
+          "key": "cv01",
+          "value": 0
+        },
+        {
+          "key": "cv04",
+          "value": 0
+        },
+        {
+          "key": "cv06",
+          "value": 0
+        },
+        {
+          "key": "cv07",
+          "value": 0
+        }
+      ],
+      "Awami_Nastaliq_Extra_Bold": [
+        {
+          "key": "hehk",
+          "value": 0
+        },
+        {
+          "key": "hedo",
+          "value": 1
+        },
+        {
+          "key": "lamv",
+          "value": 0
+        },
+        {
+          "key": "cv85",
+          "value": 0
+        },
+        {
+          "key": "cv78",
+          "value": 1
+        },
+        {
+          "key": "hamz",
+          "value": 0
+        },
+        {
+          "key": "wdsp",
+          "value": 2
+        },
+        {
+          "key": "agca",
+          "value": 3
+        },
+        {
+          "key": "shrt",
+          "value": 2
+        },
+        {
+          "key": "punc",
+          "value": 2
+        }
+      ],
+      "Awami_Nastaliq_Medium": [
+        {
+          "key": "hehk",
+          "value": 0
+        },
+        {
+          "key": "hedo",
+          "value": 1
+        },
+        {
+          "key": "lamv",
+          "value": 0
+        },
+        {
+          "key": "cv85",
+          "value": 0
+        },
+        {
+          "key": "cv78",
+          "value": 1
+        },
+        {
+          "key": "hamz",
+          "value": 0
+        },
+        {
+          "key": "wdsp",
+          "value": 2
+        },
+        {
+          "key": "agca",
+          "value": 3
+        },
+        {
+          "key": "shrt",
+          "value": 2
+        },
+        {
+          "key": "punc",
+          "value": 2
+        }
+      ],
+      "Awami_Nastaliq_Semi_Bold": [
+        {
+          "key": "hehk",
+          "value": 0
+        },
+        {
+          "key": "hedo",
+          "value": 1
+        },
+        {
+          "key": "lamv",
+          "value": 0
+        },
+        {
+          "key": "cv85",
+          "value": 0
+        },
+        {
+          "key": "cv78",
+          "value": 1
+        },
+        {
+          "key": "hamz",
+          "value": 0
+        },
+        {
+          "key": "wdsp",
+          "value": 2
+        },
+        {
+          "key": "agca",
+          "value": 3
+        },
+        {
+          "key": "shrt",
+          "value": 2
+        },
+        {
+          "key": "punc",
+          "value": 2
+        }
+      ],
       "Awami_Nastaliq": [
         {
           "key": "hehk",
@@ -49,6 +389,354 @@
         {
           "key": "punc",
           "value": 2
+        }
+      ],
+      "Charis_SIL": [
+        {
+          "key": "smcp",
+          "value": 0
+        },
+        {
+          "key": "c2sc",
+          "value": 0
+        },
+        {
+          "key": "ss01",
+          "value": 0
+        },
+        {
+          "key": "ss11",
+          "value": 0
+        },
+        {
+          "key": "ss12",
+          "value": 0
+        },
+        {
+          "key": "ss04",
+          "value": 0
+        },
+        {
+          "key": "ss05",
+          "value": 0
+        },
+        {
+          "key": "cv13",
+          "value": 0
+        },
+        {
+          "key": "cv17",
+          "value": 0
+        },
+        {
+          "key": "cv28",
+          "value": 0
+        },
+        {
+          "key": "cv37",
+          "value": 0
+        },
+        {
+          "key": "cv43",
+          "value": 0
+        },
+        {
+          "key": "cv44",
+          "value": 0
+        },
+        {
+          "key": "cv46",
+          "value": 0
+        },
+        {
+          "key": "cv47",
+          "value": 0
+        },
+        {
+          "key": "cv49",
+          "value": 0
+        },
+        {
+          "key": "cv55",
+          "value": 0
+        },
+        {
+          "key": "cv57",
+          "value": 0
+        },
+        {
+          "key": "cv62",
+          "value": 0
+        },
+        {
+          "key": "cv68",
+          "value": 0
+        },
+        {
+          "key": "cv20",
+          "value": 0
+        },
+        {
+          "key": "cv19",
+          "value": 0
+        },
+        {
+          "key": "cv25",
+          "value": 0
+        },
+        {
+          "key": "cv69",
+          "value": 0
+        },
+        {
+          "key": "cv75",
+          "value": 0
+        },
+        {
+          "key": "cv79",
+          "value": 0
+        },
+        {
+          "key": "cv76",
+          "value": 0
+        },
+        {
+          "key": "cv77",
+          "value": 0
+        },
+        {
+          "key": "cv70",
+          "value": 0
+        },
+        {
+          "key": "cv71",
+          "value": 0
+        },
+        {
+          "key": "cv98",
+          "value": 0
+        },
+        {
+          "key": "cv80",
+          "value": 0
+        },
+        {
+          "key": "cv81",
+          "value": 0
+        },
+        {
+          "key": "cv82",
+          "value": 0
+        },
+        {
+          "key": "cv84",
+          "value": 0
+        },
+        {
+          "key": "cv90",
+          "value": 0
+        },
+        {
+          "key": "cv91",
+          "value": 0
+        },
+        {
+          "key": "cv92",
+          "value": 0
+        },
+        {
+          "key": "subs",
+          "value": 0
+        },
+        {
+          "key": "sups",
+          "value": 0
+        },
+        {
+          "key": "frac",
+          "value": 0
+        }
+      ],
+      "Gentium_Book_Plus": [
+        {
+          "key": "smcp",
+          "value": 0
+        },
+        {
+          "key": "c2sc",
+          "value": 0
+        },
+        {
+          "key": "ss01",
+          "value": 0
+        },
+        {
+          "key": "ss11",
+          "value": 0
+        },
+        {
+          "key": "ss12",
+          "value": 0
+        },
+        {
+          "key": "ss04",
+          "value": 0
+        },
+        {
+          "key": "ss05",
+          "value": 0
+        },
+        {
+          "key": "cv13",
+          "value": 0
+        },
+        {
+          "key": "cv17",
+          "value": 0
+        },
+        {
+          "key": "cv28",
+          "value": 0
+        },
+        {
+          "key": "cv37",
+          "value": 0
+        },
+        {
+          "key": "cv43",
+          "value": 0
+        },
+        {
+          "key": "cv44",
+          "value": 0
+        },
+        {
+          "key": "cv46",
+          "value": 0
+        },
+        {
+          "key": "cv47",
+          "value": 0
+        },
+        {
+          "key": "cv49",
+          "value": 0
+        },
+        {
+          "key": "cv55",
+          "value": 0
+        },
+        {
+          "key": "cv57",
+          "value": 0
+        },
+        {
+          "key": "cv62",
+          "value": 0
+        },
+        {
+          "key": "cv68",
+          "value": 0
+        },
+        {
+          "key": "cv20",
+          "value": 0
+        },
+        {
+          "key": "cv19",
+          "value": 0
+        },
+        {
+          "key": "cv25",
+          "value": 0
+        },
+        {
+          "key": "cv69",
+          "value": 0
+        },
+        {
+          "key": "ss07",
+          "value": 0
+        },
+        {
+          "key": "cv75",
+          "value": 0
+        },
+        {
+          "key": "cv79",
+          "value": 0
+        },
+        {
+          "key": "cv76",
+          "value": 0
+        },
+        {
+          "key": "cv77",
+          "value": 0
+        },
+        {
+          "key": "cv70",
+          "value": 0
+        },
+        {
+          "key": "cv71",
+          "value": 0
+        },
+        {
+          "key": "cv98",
+          "value": 0
+        },
+        {
+          "key": "cv80",
+          "value": 0
+        },
+        {
+          "key": "cv81",
+          "value": 0
+        },
+        {
+          "key": "cv82",
+          "value": 0
+        },
+        {
+          "key": "cv84",
+          "value": 0
+        },
+        {
+          "key": "cv78",
+          "value": 0
+        },
+        {
+          "key": "cv83",
+          "value": 0
+        },
+        {
+          "key": "cv14",
+          "value": 0
+        },
+        {
+          "key": "cv90",
+          "value": 0
+        },
+        {
+          "key": "cv91",
+          "value": 0
+        },
+        {
+          "key": "cv92",
+          "value": 0
+        },
+        {
+          "key": "subs",
+          "value": 0
+        },
+        {
+          "key": "sups",
+          "value": 0
+        },
+        {
+          "key": "frac",
+          "value": 0
         }
       ],
       "Gentium_Plus": [
@@ -230,6 +918,72 @@
         },
         {
           "key": "frac",
+          "value": 0
+        }
+      ],
+      "Padauk_Book": [
+        {
+          "key": "cv01",
+          "value": 0
+        },
+        {
+          "key": "cv02",
+          "value": 0
+        },
+        {
+          "key": "cv03",
+          "value": 0
+        },
+        {
+          "key": "cv04",
+          "value": 0
+        },
+        {
+          "key": "cv05",
+          "value": 0
+        },
+        {
+          "key": "cv06",
+          "value": 0
+        },
+        {
+          "key": "cv07",
+          "value": 0
+        },
+        {
+          "key": "cv09",
+          "value": 0
+        },
+        {
+          "key": "cv10",
+          "value": 0
+        },
+        {
+          "key": "lldt",
+          "value": 0
+        },
+        {
+          "key": "ulon",
+          "value": 0
+        },
+        {
+          "key": "utal",
+          "value": 0
+        },
+        {
+          "key": "dotc",
+          "value": 1
+        },
+        {
+          "key": "nnya",
+          "value": 0
+        },
+        {
+          "key": "vtta",
+          "value": 0
+        },
+        {
+          "key": "dotr",
           "value": 0
         }
       ],

--- a/webfonts/_webfonts.css
+++ b/webfonts/_webfonts.css
@@ -7,5 +7,4 @@
 
 .fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus {
   font-family: 'Pankosmia-Cardo', 'Pankosmia-Ezra SIL', 'Pankosmia-Padauk', 'Pankosmia-Awami Nastaliq', 'Pankosmia-Noto Nastaliq Urdu', 'Pankosmia-Gentium Plus';
-  font-size: 200%;
 }

--- a/webfonts/pankosmia-Andika.css
+++ b/webfonts/pankosmia-Andika.css
@@ -1,0 +1,46 @@
+/* Copyright (c) 2000-2024, SIL International (https://www.sil.org/) with Reserved Font Names "Andika" and "SIL".*/
+/* This Font Software is licensed under the SIL Open Font License, Version 1.1. See https://openfontlicense.org/ .*/
+
+/* normal */
+@font-face {
+  font-family: 'Pankosmia-Andika';
+  font-style: normal;
+  font-weight: normal; /* 400 Normal (Regular) */
+  src: url(./andika/Andika-Regular.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
+
+/* italic */
+@font-face {
+  font-family: 'Pankosmia-Andika';
+  font-style: italic;
+  font-weight: normal; /* 400 Normal (Regular) */
+  src: url(./andika/Andika-Italic.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
+
+/* bold */
+@font-face {
+  font-family: 'Pankosmia-Andika';
+  font-style: normal;
+  font-weight: bold; /* 700 */
+  src: url(./andika/Andika-Bold.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
+
+/* bold italic */
+@font-face {
+  font-family: 'Pankosmia-Andika';
+  font-style: italic;
+  font-weight: bold; /* 700 */
+  src: url(./andika/Andika-BoldItalic.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}

--- a/webfonts/pankosmia-Awami_Nastaliq_Extra_Bold.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Extra_Bold.css
@@ -1,0 +1,57 @@
+/* Copyright (c) 2000-2024, SIL International (https://www.sil.org/) with Reserved Font Names "Awami" and "SIL".*/
+/* This Font Software is licensed under the SIL Open Font License, Version 1.1. See https://openfontlicense.org/ .*/
+
+/* Only load if Firefox is in use. */
+@-moz-document url-prefix() {
+  /* normal */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Extra Bold';
+    font-style: normal;
+    font-weight: normal; /* This is really Semi Bold (Demi Bold) - 600 */
+    src: url(./awami/AwamiNastaliq-SemiBold.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+
+  /* italic */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Extra Bold';
+    font-style: italic; /* Doesn't exist */
+    font-weight: normal; /* This is really Semi Bold (Demi Bold) - 600 */
+    src: url(./awami/AwamiNastaliq-SemiBold.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+
+  /* bold */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Extra Bold';
+    font-style: normal;
+    font-weight: bold; /* This is really Extra Bold (Ultra Bold) - 800 */
+    src: url(./awami/AwamiNastaliq-ExtraBold.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+
+  /* bold italic */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Extra Bold';
+    font-style: italic; /* Doesn't exist */
+    font-weight: bold; /* This is really Extra Bold (Ultra Bold) - 800 */
+    src: url(./awami/AwamiNastaliq-ExtraBold.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+}

--- a/webfonts/pankosmia-Awami_Nastaliq_Medium.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Medium.css
@@ -1,0 +1,57 @@
+/* Copyright (c) 2000-2024, SIL International (https://www.sil.org/) with Reserved Font Names "Awami" and "SIL".*/
+/* This Font Software is licensed under the SIL Open Font License, Version 1.1. See https://openfontlicense.org/ .*/
+
+/* Only load if Firefox is in use. */
+@-moz-document url-prefix() {
+  /* normal */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Medium';
+    font-style: normal;
+    font-weight: normal; /* 400 Normal (Regular) */
+    src: url(./awami/AwamiNastaliq-Regular.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+
+  /* italic */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Medium';
+    font-style: italic; /* Doesn't exist */
+    font-weight: normal; /* 400 Normal (Regular) */
+    src: url(./awami/AwamiNastaliq-Regular.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+
+  /* bold */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Medium';
+    font-weight: normal; /* 400 Normal (Regular) */
+    font-weight: bold; /* This is really Medium - 500 */
+    src: url(./awami/AwamiNastaliq-Medium.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+
+  /* bold italic */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Medium';
+    font-style: italic; /* Doesn't exist */
+    font-weight: bold; /* 700 */
+    src: url(./awami/AwamiNastaliq-Medium.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+}

--- a/webfonts/pankosmia-Awami_Nastaliq_Semi_Bold.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Semi_Bold.css
@@ -1,0 +1,57 @@
+/* Copyright (c) 2000-2024, SIL International (https://www.sil.org/) with Reserved Font Names "Awami" and "SIL".*/
+/* This Font Software is licensed under the SIL Open Font License, Version 1.1. See https://openfontlicense.org/ .*/
+
+/* Only load if Firefox is in use. */
+@-moz-document url-prefix() {
+  /* normal */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Semi Bold';
+    font-style: normal;
+    font-weight: normal; /* 400 Normal (Regular) */
+    src: url(./awami/AwamiNastaliq-Regular.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+
+  /* italic */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Semi Bold';
+    font-style: italic; /* Doesn't exist */
+    font-weight: normal; /* 400 Normal (Regular) */
+    src: url(./awami/AwamiNastaliq-Regular.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+
+  /* bold */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Semi Bold';
+    font-style: normal;
+    font-weight: bold; /* This is really Semi Bold (Demi Bold) - 600 */
+    src: url(./awami/AwamiNastaliq-SemiBold.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+
+  /* bold italic */
+  @font-face {
+    font-family: 'Pankosmia-Awami Nastaliq Semi Bold';
+    font-style: italic; /* Doesn't exist */
+    font-weight: bold; /* 700 */
+    src: url(./awami/AwamiNastaliq-SemiBold.woff2);
+    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    font-display: swap;
+    font-feature-settings: %%FONTFEATURES%%;
+    -moz-font-feature-settings: %%FONTFEATURES%%;
+    -webkit-font-feature-settings: %%FONTFEATURES%%;
+  }
+}

--- a/webfonts/pankosmia-Charis_SIL.css
+++ b/webfonts/pankosmia-Charis_SIL.css
@@ -1,0 +1,46 @@
+/* Copyright (c) 2000-2023, SIL International (https://www.sil.org/) with Reserved Font Names "Charis" and "SIL".*/
+/* This Font Software is licensed under the SIL Open Font License, Version 1.1. See https://openfontlicense.org/ .*/
+
+/* normal */
+@font-face {
+  font-family: 'Pankosmia-Charis SIL';
+  font-style: normal;
+  font-weight: normal; /* 400 Normal (Regular) */
+  src: url(./charis/CharisSIL-Regular.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
+
+/* italic */
+@font-face {
+  font-family: 'Pankosmia-Charis SIL';
+  font-style: italic;
+  font-weight: normal; /* 400 Normal (Regular) */
+  src: url(./charis/CharisSIL-Italic.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
+
+/* bold */
+@font-face {
+  font-family: 'Pankosmia-Charis SIL';
+  font-style: normal;
+  font-weight: bold; /* 700 */
+  src: url(./charis/CharisSIL-Bold.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
+
+/* bold italic */
+@font-face {
+  font-family: 'Pankosmia-Charis SIL';
+  font-style: italic;
+  font-weight: bold; /* 700 */
+  src: url(./charis/CharisSIL-BoldItalic.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}

--- a/webfonts/pankosmia-Gentium_Book_Plus.css
+++ b/webfonts/pankosmia-Gentium_Book_Plus.css
@@ -1,0 +1,46 @@
+/* Copyright (c) 2000-2023, SIL International (https://www.sil.org/) with Reserved Font Names "Gentium" and "SIL".*/
+/* This Font Software is licensed under the SIL Open Font License, Version 1.1. See https://openfontlicense.org/ .*/
+
+/* normal */
+@font-face {
+  font-family: 'Pankosmia-Gentium Book Plus';
+  font-style: normal;
+  font-weight: normal; /* 400 Normal (Regular) */
+  src: url(./gentiumplus/GentiumBookPlus-Regular.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
+
+/* italic */
+@font-face {
+  font-family: 'Pankosmia-Gentium Book Plus';
+  font-style: italic;
+  font-weight: normal; /* 400 Normal (Regular) */
+  src: url(./gentiumplus/GentiumBookPlus-Italic.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
+
+/* bold */
+@font-face {
+  font-family: 'Pankosmia-Gentium Book Plus';
+  font-style: normal;
+  font-weight: bold; /* 700 */
+  src: url(./gentiumplus/GentiumBookPlus-Bold.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}
+
+/* bold italic */
+@font-face {
+  font-family: 'Pankosmia-Gentium Book Plus';
+  font-style: italic;
+  font-weight: bold; /* 700 */
+  src: url(./gentiumplus/GentiumBookPlus-BoldItalic.woff2);
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;
+}

--- a/webfonts/pankosmia-Padauk_Book.css
+++ b/webfonts/pankosmia-Padauk_Book.css
@@ -1,0 +1,50 @@
+/* Copyright (c) 2021, SIL International (https://www.sil.org/) with Reserved Font Names "Padauk", "Namkio" and "Deemawso".*/
+/* This Font Software is licensed under the SIL Open Font License, Version 1.1. See https://openfontlicense.org/ .*/
+
+/* normal */
+@font-face {
+  font-family: 'Pankosmia-Padauk Book';
+  font-style: normal;
+  font-weight: normal; /* 400 Normal (Regular) */
+  src: url(./padauk/PadaukBook-Regular.woff2);
+  unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
+  font-display: swap;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;}
+
+/* italic */
+@font-face {
+  font-family: 'Pankosmia-Padauk Book';
+  font-style: italic; /* Doesn't exist */
+  font-weight: normal; /* 400 Normal (Regular) */
+  src: url(./padauk/PadaukBook-Regular.woff2);
+  unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
+  font-display: swap;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;}
+
+/* bold */
+@font-face {
+  font-family: 'Pankosmia-Padauk Book';
+  font-style: normal;
+  font-weight: bold; /* 700 */
+  src: url(./padauk/PadaukBook-Bold.woff2);
+  unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
+  font-display: swap;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;}
+
+/* bold italic */
+@font-face {
+  font-family: 'Pankosmia-Padauk Book';
+  font-style: italic; /* Doesn't exist */
+  font-weight: bold; /* 700 */
+  src: url(./padauk/PadaukBook-Bold.woff2);
+  unicode-range: U+1000-109F, U+AA60-AA7F, U+A9E0-A9FF, U+116D0-116FF, U+A900-A92F;
+  font-display: swap;
+  font-feature-settings: %%FONTFEATURES%%;
+  -moz-font-feature-settings: %%FONTFEATURES%%;
+  -webkit-font-feature-settings: %%FONTFEATURES%%;}


### PR DESCRIPTION
- Removed font-size from the sole panksomia-web font_set class.
  - Note: We are unable to control font-size in @font-face; It does not correlated with unicode-range via css.  Will need to utilize a different method for script size variation.
- Updated user settings templates with font feature settings defaults for remaining fonts for which we have font feature settings setup.
- Added css templates with %%FONTFEATURES%% for remaining fonts for which we have font feature settings setup.
  - Note: pankosmia-web only contains woff files for the default font_set
  - Note: panksomia-web does not contain @font-face configurations beyond default and font-feature-settings templates.