### PR TITLE
remove space char from Awami Nastaliq unicode ranges

### DIFF
--- a/webfonts/pankosmia-Awami_Nastaliq.css
+++ b/webfonts/pankosmia-Awami_Nastaliq.css
@@ -9,7 +9,7 @@
     font-style: normal;
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -22,7 +22,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -35,7 +35,7 @@
     font-style: normal;
     font-weight: bold; /* 700 */
     src: url(./awami/AwamiNastaliq-Bold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -48,7 +48,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: bold; /* 700 */
     src: url(./awami/AwamiNastaliq-Bold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;

--- a/webfonts/pankosmia-Awami_Nastaliq_Extra_Bold.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Extra_Bold.css
@@ -9,7 +9,7 @@
     font-style: normal;
     font-weight: normal; /* This is really Semi Bold (Demi Bold) - 600 */
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -22,7 +22,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: normal; /* This is really Semi Bold (Demi Bold) - 600 */
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -35,7 +35,7 @@
     font-style: normal;
     font-weight: bold; /* This is really Extra Bold (Ultra Bold) - 800 */
     src: url(./awami/AwamiNastaliq-ExtraBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -48,7 +48,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: bold; /* This is really Extra Bold (Ultra Bold) - 800 */
     src: url(./awami/AwamiNastaliq-ExtraBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;

--- a/webfonts/pankosmia-Awami_Nastaliq_Medium.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Medium.css
@@ -9,7 +9,7 @@
     font-style: normal;
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -22,7 +22,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -35,7 +35,7 @@
     font-weight: normal; /* 400 Normal (Regular) */
     font-weight: bold; /* This is really Medium - 500 */
     src: url(./awami/AwamiNastaliq-Medium.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -48,7 +48,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: bold; /* 700 */
     src: url(./awami/AwamiNastaliq-Medium.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;

--- a/webfonts/pankosmia-Awami_Nastaliq_Semi_Bold.css
+++ b/webfonts/pankosmia-Awami_Nastaliq_Semi_Bold.css
@@ -9,7 +9,7 @@
     font-style: normal;
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -22,7 +22,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: normal; /* 400 Normal (Regular) */
     src: url(./awami/AwamiNastaliq-Regular.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -35,7 +35,7 @@
     font-style: normal;
     font-weight: bold; /* This is really Semi Bold (Demi Bold) - 600 */
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;
@@ -48,7 +48,7 @@
     font-style: italic; /* Doesn't exist */
     font-weight: bold; /* 700 */
     src: url(./awami/AwamiNastaliq-SemiBold.woff2);
-    unicode-range: U+0020, U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
+    unicode-range: U+0600-06FF, U+0750-077F, U+FB50-FDFF, U+FE70-FEFF, U+08A0-08FF, U+0870-089F, U+10EC0-10EFF;
     font-display: swap;
     font-feature-settings: %%FONTFEATURES%%;
     -moz-font-feature-settings: %%FONTFEATURES%%;


### PR DESCRIPTION
- remove U+0020 from Awami Nastaliq unicode ranges to address [space and cursor size](https://github.com/orgs/pankosmia/discussions/5#discussioncomment-12936723)