### PR TITLE
Ignore archived files by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pankosmia_web"
 description = "A web server for pankosmia desktop applications"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 license = "MIT"
 homepage = "https://xenizo.fr"

--- a/src/endpoints/burrito2/summary_metadatas.rs
+++ b/src/endpoints/burrito2/summary_metadatas.rs
@@ -49,6 +49,7 @@ pub fn summary_metadatas(
                     if server_org == "_local_/_quarantine_" {
                         continue;
                     }
+                    if server_org == "_local_/_archive_" {continue};
                 }
             }
             if !std::path::Path::new(&uw_org_path_ob).is_dir() {

--- a/src/endpoints/git2/list_local_repos.rs
+++ b/src/endpoints/git2/list_local_repos.rs
@@ -38,6 +38,7 @@ pub fn list_local_repos(state: &State<AppSettings>) -> status::Custom<(ContentTy
                 continue;
             }
             if server_org == "_local_/_quarantine_" {continue};
+            if server_org == "_local_/_archive_" {continue};
             for repo_path in std::fs::read_dir(uw_org_path_ob).unwrap() {
                 let uw_repo_path_ob = repo_path.unwrap().path();
                 let repo_leaf = uw_repo_path_ob.file_name().unwrap();


### PR DESCRIPTION
The content page filter now ignores archived files by default. 