### PR TITLE
Rename the audio chapter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pankosmia_web"
 description = "A web server for pankosmia desktop applications"
-version = "0.16.13"
+version = "0.16.14"
 edition = "2021"
 license = "MIT"
 homepage = "https://xenizo.fr"

--- a/src/endpoints/audio/compile_chapter_audio.rs
+++ b/src/endpoints/audio/compile_chapter_audio.rs
@@ -139,7 +139,18 @@ pub fn compile_chapter_audio(
     }
     let list_path_str = list_path.to_string_lossy().to_string();
 
-    let output_path = format!("{}/{}.mp3", scan_dir, cc);
+    let book_name = match &json_form.book {
+        Some(b) if !b.is_empty() => b.clone(),
+        _ => "".to_string(),
+    };
+    let cc_num: u32 = cc.trim().parse().unwrap();
+
+    let output_name = if book_name.trim().is_empty() {
+        format!("{:02}", cc_num)
+    } else {
+        format!("{}_{:03}", book_name.trim(), cc_num)
+    };
+    let output_path = format!("{}/{}.mp3", scan_dir, output_name);
 
     let mut cmd = FfmpegCommand::new();
     cmd.overwrite()

--- a/src/endpoints/audio/compile_chapter_audio.rs
+++ b/src/endpoints/audio/compile_chapter_audio.rs
@@ -143,7 +143,7 @@ pub fn compile_chapter_audio(
         Some(b) if !b.is_empty() => b.clone(),
         _ => "".to_string(),
     };
-    let cc_num: u32 = cc.trim().parse().unwrap();
+    let cc_num: u32 = cc.trim().parse().expect("Chapter number must be a number");
 
     let output_name = if book_name.trim().is_empty() {
         format!("{:02}", cc_num)


### PR DESCRIPTION
### Overview
This PR aims to change the naming convention for output files generated by compiling files in Audio Translation.

### Changes
`compile_chapter_audio.rs`  edited the output file name to use 3 numbers instead of 2 for audio translation.