### PR TITLE
Edited ffmpeg related endpoints to use the pankosmia ffmpeg install

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pankosmia_web"
 description = "A web server for pankosmia desktop applications"
-version = "0.16.14"
+version = "0.16.15"
 edition = "2021"
 license = "MIT"
 homepage = "https://xenizo.fr"

--- a/src/endpoints/audio/compile_audio.rs
+++ b/src/endpoints/audio/compile_audio.rs
@@ -42,6 +42,7 @@ pub struct CompileAudioForm {
     chapter: u32,
     paragraph: u32,
     book: Option<String>,
+    ffmpeg_path: Option<String>,
 }
 
 #[post("/compile/<repo_path..>", format = "json", data = "<json_form>")]
@@ -50,12 +51,22 @@ pub fn compile_audio(
     repo_path: PathBuf,
     json_form: Json<CompileAudioForm>,
 ) -> status::Custom<(ContentType, String)> {
-    if ffmpeg_version().is_err() {
+    
+    let ffmpeg_path = json_form
+        .ffmpeg_path
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("");
+    let mut cmd = if ffmpeg_version().is_ok() {
+        FfmpegCommand::new()
+    } else if !ffmpeg_path.is_empty() {
+        FfmpegCommand::new_with_path(ffmpeg_path)
+    } else {
         return not_ok_json_response(
             Status::InternalServerError,
             make_bad_json_data_response("ffmpeg not found".to_string()),
         );
-    }
+    };
 
     let path_components: Components<'_> = repo_path.components();
     if !check_path_components(&mut path_components.clone()) {
@@ -214,7 +225,6 @@ pub fn compile_audio(
 
     let output_path = format!("{}/{}-{}.mp3", dir, cc, pp);
 
-    let mut cmd = FfmpegCommand::new();
     cmd.overwrite();
     for p in &input_paths {
         cmd.input(p);

--- a/src/endpoints/audio/compile_chapter_audio.rs
+++ b/src/endpoints/audio/compile_chapter_audio.rs
@@ -39,6 +39,7 @@ use std::path::{Components, PathBuf};
 pub struct CompileChapterAudioForm {
     chapter: u32,
     book: Option<String>,
+    ffmpeg_path: Option<String>,
 }
 
 #[post("/compile-chapter/<repo_path..>", format = "json", data = "<json_form>")]
@@ -47,12 +48,22 @@ pub fn compile_chapter_audio(
     repo_path: PathBuf,
     json_form: Json<CompileChapterAudioForm>,
 ) -> status::Custom<(ContentType, String)> {
-    if ffmpeg_version().is_err() {
+
+    let ffmpeg_path = json_form
+        .ffmpeg_path
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("");
+    let mut cmd = if ffmpeg_version().is_ok() {
+        FfmpegCommand::new()
+    } else if !ffmpeg_path.is_empty() {
+        FfmpegCommand::new_with_path(ffmpeg_path)
+    } else {
         return not_ok_json_response(
             Status::InternalServerError,
             make_bad_json_data_response("ffmpeg not found".to_string()),
         );
-    }
+    };
 
     let path_components: Components<'_> = repo_path.components();
     if !check_path_components(&mut path_components.clone()) {
@@ -152,7 +163,6 @@ pub fn compile_chapter_audio(
     };
     let output_path = format!("{}/{}.mp3", scan_dir, output_name);
 
-    let mut cmd = FfmpegCommand::new();
     cmd.overwrite()
         .args(&["-f", "concat", "-safe", "0"])
         .input(list_path_str.as_str())

--- a/src/endpoints/video/obs_para.rs
+++ b/src/endpoints/video/obs_para.rs
@@ -18,15 +18,26 @@ use std::path::{Components, PathBuf};
 ///
 /// Typically mounted as **`/video/obs-para/<repo_path>`**
 ///
+/// Construit la vidéo d'un paragraphe (image OBS + audio).
+///
+/// L'audio utilisé est, par défaut, le mp3 compilé par l'endpoint audio
+/// (`compile_audio`), à savoir :
+///   - `audio_content/[{book}/]{CC}-{PP}/{CC}-{PP}.mp3`
+///
+/// `audio_path` (optionnel, relatif à `ingredients/`) permet de surcharger ce
+/// chemin si besoin.
+///
 /// Example body:
 ///
-/// `{"story_n": 1, "para_n": 1, "audio_path": "audio_content/01-01/01-01_0_1.mp3"}`
+/// `{"story_n": 1, "para_n": 1}`  ou  `{"story_n": 1, "para_n": 1, "audio_path": "audio_content/01-01/01-01.mp3"}`
 
 #[derive(Deserialize)]
 pub struct ObsParaForm {
     story_n: i32,
     para_n: i32,
-    audio_path: String,
+    audio_path: Option<String>,
+    book: Option<String>,
+    ffmpeg_path: Option<String>,
 }
 
 #[post("/obs-para/<repo_path..>", format = "json", data = "<json_form>")]
@@ -35,15 +46,22 @@ pub fn obs_para_video(
     repo_path: PathBuf,
     json_form: Json<ObsParaForm>,
 ) -> status::Custom<(ContentType, String)> {
-    match ffmpeg_version() {
-        Ok(_) => {}
-        Err(_) => {
-            return not_ok_json_response(
-                Status::InternalServerError,
-                make_bad_json_data_response("ffmpeg not found".to_string()),
-            )
-        }
-    }
+    
+    let ffmpeg_path = json_form
+        .ffmpeg_path
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("");
+    let mut cmd = if ffmpeg_version().is_ok() {
+        FfmpegCommand::new()
+    } else if !ffmpeg_path.is_empty() {
+        FfmpegCommand::new_with_path(ffmpeg_path)
+    } else {
+        return not_ok_json_response(
+            Status::InternalServerError,
+            make_bad_json_data_response("ffmpeg not found".to_string()),
+        );
+    };
     let path_components: Components<'_> = repo_path.components();
     if check_path_components(&mut path_components.clone()) {
         let repo_dir = state.repo_dir.lock().unwrap().clone();
@@ -74,9 +92,20 @@ pub fn obs_para_video(
             json_form.para_n.to_string()
         };
 
-        // Chemin du fichier video
-        let audio_path = format!("{}/ingredients/{}", repo_path, json_form.audio_path);
-        // Vérifier si le fichier video existe
+        let rel_audio_path = match &json_form.audio_path {
+            Some(p) if !p.trim().is_empty() => p.clone(),
+            _ => {
+                let dir_name = format!("{}-{}", story_string, para_string);
+                match &json_form.book {
+                    Some(b) if !b.is_empty() => {
+                        format!("audio_content/{}/{}/{}.mp3", b, dir_name, dir_name)
+                    }
+                    _ => format!("audio_content/{}/{}.mp3", dir_name, dir_name),
+                }
+            }
+        };
+        let audio_path = format!("{}/ingredients/{}", repo_path, rel_audio_path);
+
         if !Path::new(&audio_path).exists() {
             return not_ok_json_response(
                 Status::NotFound,
@@ -109,7 +138,7 @@ pub fn obs_para_video(
 
         // println!("Video path: {}", video_path);
         // Créer la vidéo et attendre la fin du traitement
-        let iter = FfmpegCommand::new()
+        let iter = cmd
             .overwrite()
             .args(&["-loop", "1"])
             .args(&["-framerate", "25"])

--- a/src/endpoints/video/obs_story.rs
+++ b/src/endpoints/video/obs_story.rs
@@ -28,6 +28,7 @@ pub struct ObsStoryForm {
     story_n: i32,
     from_para_n: Option<i32>,
     to_para_n: Option<i32>,
+    ffmpeg_path: Option<String>,
 }
 
 #[post("/obs-story/<repo_path..>", format = "json", data = "<json_form>")]
@@ -36,15 +37,22 @@ pub fn obs_story_video(
     repo_path: PathBuf,
     json_form: Json<ObsStoryForm>,
 ) -> status::Custom<(ContentType, String)> {
-    match ffmpeg_version() {
-        Ok(_) => {}
-        Err(_) => {
-            return not_ok_json_response(
-                Status::InternalServerError,
-                make_bad_json_data_response("ffmpeg not found".to_string()),
-            )
-        }
-    }
+    
+    let ffmpeg_path = json_form
+        .ffmpeg_path
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("");
+    let mut cmd = if ffmpeg_version().is_ok() {
+        FfmpegCommand::new()
+    } else if !ffmpeg_path.is_empty() {
+        FfmpegCommand::new_with_path(ffmpeg_path)
+    } else {
+        return not_ok_json_response(
+            Status::InternalServerError,
+            make_bad_json_data_response("ffmpeg not found".to_string()),
+        );
+    };
     let path_components: Components<'_> = repo_path.components();
     if check_path_components(&mut path_components.clone()) {
         let repo_dir = state.repo_dir.lock().unwrap().clone();
@@ -123,7 +131,7 @@ pub fn obs_story_video(
 
         // // Créer la vidéo finale
         let video_path = format!("{}/obs-story-{}.mp4", video_content_path, json_form.story_n);
-        let video_writer = FfmpegCommand::new()
+        let video_writer = cmd
             .overwrite()
 			.args(args_refs)
             .codec_video("libx264")


### PR DESCRIPTION
### Overview
This PR makes it possible to use the ffmpeg binary downloaded into `_assets` instead of relying only on a system-wide install.

### Changes
- `compile_audio.rs`, `compile_chapter_audio.rs`, `obs_para.rs`, `obs_story.rs`: added an optional `ffmpeg_path` field to the request body. When provided, ffmpeg runs from that path; otherwise it falls back to the system ffmpeg.
- Fixed video generation to follow the new compiled-audio file naming. The pipeline is bottom-up: each paragraph video is rendered from its OBS image + the compiled paragraph mp3 (`obs-para-{CC}-{PP}.mp4`), then `obs-story` concatenates those paragraph videos into the final story video (video_paragraph → video_story). This flow is still subject to change and debate (it can be audio_p to video_s or audio_s to video_s).