### PR TITLE
FFmpeg path endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pankosmia_web"
 description = "A web server for pankosmia desktop applications"
-version = "0.16.15"
+version = "0.16.17"
 edition = "2021"
 license = "MIT"
 homepage = "https://xenizo.fr"

--- a/src/endpoints/audio/ffmpeg_path.rs
+++ b/src/endpoints/audio/ffmpeg_path.rs
@@ -9,12 +9,12 @@ use serde_json::json;
 ///
 /// Typically mounted as **`/audio/ffmpeg-path`**
 ///
-/// Renvoie le chemin du binaire ffmpeg téléchargé localement par l'app desktop
-/// (`~/pankosmia/_assets/ffmpeg/**`), que le client peut ensuite transmettre
-/// aux endpoints de compilation via le champ `ffmpeg_path`.
+/// Returns the path to the ffmpeg binary downloaded locally by the desktop app
+/// (`~/pankosmia/_assets/ffmpeg/**`), which the client can then forward to the
+/// compilation endpoints via the `ffmpeg_path` field.
 ///
-/// `payload.path` vaut `null` si aucun ffmpeg téléchargé n'est trouvé (le
-/// client s'appuiera alors sur le ffmpeg système).
+/// `payload.path` is `null` when no downloaded ffmpeg is found (the client then
+/// falls back to the system ffmpeg).
 #[get("/ffmpeg-path")]
 pub fn ffmpeg_path() -> status::Custom<(ContentType, String)> {
     json_payload_response(Status::Ok, json!({ "path": find_bundled_ffmpeg() }))

--- a/src/endpoints/audio/ffmpeg_path.rs
+++ b/src/endpoints/audio/ffmpeg_path.rs
@@ -1,6 +1,7 @@
+use crate::structs::AppSettings;
 use crate::utils::ffmpeg::find_bundled_ffmpeg;
 use crate::utils::response::json_payload_response;
-use rocket::get;
+use rocket::{get, State};
 use rocket::http::{ContentType, Status};
 use rocket::response::status;
 use serde_json::json;
@@ -16,6 +17,7 @@ use serde_json::json;
 /// `payload.path` is `null` when no downloaded ffmpeg is found (the client then
 /// falls back to the system ffmpeg).
 #[get("/ffmpeg-path")]
-pub fn ffmpeg_path() -> status::Custom<(ContentType, String)> {
-    json_payload_response(Status::Ok, json!({ "path": find_bundled_ffmpeg() }))
+pub fn ffmpeg_path(state: &State<AppSettings>) -> status::Custom<(ContentType, String)> {
+    let working_dir = state.working_dir.clone();
+    json_payload_response(Status::Ok, json!({ "path": find_bundled_ffmpeg(working_dir) }))
 }

--- a/src/endpoints/audio/ffmpeg_path.rs
+++ b/src/endpoints/audio/ffmpeg_path.rs
@@ -1,0 +1,21 @@
+use crate::utils::ffmpeg::find_bundled_ffmpeg;
+use crate::utils::response::json_payload_response;
+use rocket::get;
+use rocket::http::{ContentType, Status};
+use rocket::response::status;
+use serde_json::json;
+
+/// *`GET /ffmpeg-path`*
+///
+/// Typically mounted as **`/audio/ffmpeg-path`**
+///
+/// Renvoie le chemin du binaire ffmpeg téléchargé localement par l'app desktop
+/// (`~/pankosmia/_assets/ffmpeg/**`), que le client peut ensuite transmettre
+/// aux endpoints de compilation via le champ `ffmpeg_path`.
+///
+/// `payload.path` vaut `null` si aucun ffmpeg téléchargé n'est trouvé (le
+/// client s'appuiera alors sur le ffmpeg système).
+#[get("/ffmpeg-path")]
+pub fn ffmpeg_path() -> status::Custom<(ContentType, String)> {
+    json_payload_response(Status::Ok, json!({ "path": find_bundled_ffmpeg() }))
+}

--- a/src/endpoints/audio/mod.rs
+++ b/src/endpoints/audio/mod.rs
@@ -1,2 +1,3 @@
 pub mod compile_audio;
 pub mod compile_chapter_audio;
+pub mod ffmpeg_path;

--- a/src/endpoints/burrito2/post_zipped_repo.rs
+++ b/src/endpoints/burrito2/post_zipped_repo.rs
@@ -34,6 +34,7 @@ fn check_burrito_zip(path: &NamedTempFile) -> bool {
             None => continue,
         };
         let out_path_string = format!("{:?}", out_path);
+        println!("zip content <{}>", &out_path_string);
         if file.is_file() {
             if out_path_string == "\"metadata.json\"" {
                 metadata_found = true;

--- a/src/utils/ffmpeg.rs
+++ b/src/utils/ffmpeg.rs
@@ -13,7 +13,7 @@ fn ffmpeg_executable_name() -> &'static str {
 /// Returns `None` if the home directory cannot be found.
 fn bundled_ffmpeg_base_dir(working_dir: String) -> Option<PathBuf> {
     let working_path_buf = PathBuf::from(working_dir);
-    Some(working_path_buf.join("pankosmia").join("_assets").join("ffmpeg"))
+    Some(working_path_buf.join("_assets").join("ffmpeg"))
 }
 
 /// Recursively searches `~/pankosmia/_assets/ffmpeg/**` for the ffmpeg binary

--- a/src/utils/ffmpeg.rs
+++ b/src/utils/ffmpeg.rs
@@ -9,10 +9,11 @@ fn ffmpeg_executable_name() -> &'static str {
     }
 }
 
-/// Directory where the desktop app downloads ffmpeg: `~/pankosmia/_assets/ffmpeg`.
+/// Directory where the desktop app downloads ffmpeg: `~/<working_dir>/_assets/ffmpeg`.
 /// Returns `None` if the home directory cannot be found.
-fn bundled_ffmpeg_base_dir() -> Option<PathBuf> {
-    home::home_dir().map(|h| h.join("pankosmia").join("_assets").join("ffmpeg"))
+fn bundled_ffmpeg_base_dir(working_dir: String) -> Option<PathBuf> {
+    let working_path_buf = PathBuf::from(working_dir);
+    Some(working_path_buf.join("pankosmia").join("_assets").join("ffmpeg"))
 }
 
 /// Recursively searches `~/pankosmia/_assets/ffmpeg/**` for the ffmpeg binary
@@ -20,8 +21,8 @@ fn bundled_ffmpeg_base_dir() -> Option<PathBuf> {
 /// present. The search is recursive because, depending on the OS/build, the
 /// binary is nested in a subdirectory (e.g. `.../7.1.1/bin/ffmpeg.exe` on
 /// Windows).
-pub(crate) fn find_bundled_ffmpeg() -> Option<String> {
-    let base = bundled_ffmpeg_base_dir()?;
+pub(crate) fn find_bundled_ffmpeg(working_dir: String) -> Option<String> {
+    let base = bundled_ffmpeg_base_dir(working_dir)?;
     if !base.is_dir() {
         return None;
     }

--- a/src/utils/ffmpeg.rs
+++ b/src/utils/ffmpeg.rs
@@ -9,11 +9,12 @@ fn ffmpeg_executable_name() -> &'static str {
     }
 }
 
-/// Directory where the desktop app downloads ffmpeg: `~/<working_dir>/_assets/ffmpeg`.
+/// Directory where the desktop app downloads ffmpeg: `~/<working_dir>/../_assets/ffmpeg`.
 /// Returns `None` if the home directory cannot be found.
 fn bundled_ffmpeg_base_dir(working_dir: String) -> Option<PathBuf> {
     let working_path_buf = PathBuf::from(working_dir);
-    Some(working_path_buf.join("_assets").join("ffmpeg"))
+    let working_path_parent_buf = working_path_buf.parent().expect("working path parent");
+    Some(working_path_parent_buf.join("_assets").join("ffmpeg"))
 }
 
 /// Recursively searches `~/pankosmia/_assets/ffmpeg/**` for the ffmpeg binary

--- a/src/utils/ffmpeg.rs
+++ b/src/utils/ffmpeg.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::path::PathBuf;
 use walkdir::WalkDir;
 
-/// Nom de l'exécutable ffmpeg selon l'OS.
 fn ffmpeg_executable_name() -> &'static str {
     match env::consts::OS {
         "windows" => "ffmpeg.exe",
@@ -10,16 +9,17 @@ fn ffmpeg_executable_name() -> &'static str {
     }
 }
 
-/// Dossier où l'app desktop télécharge ffmpeg : `~/pankosmia/_assets/ffmpeg`.
-/// Renvoie `None` si le home dir est introuvable.
+/// Directory where the desktop app downloads ffmpeg: `~/pankosmia/_assets/ffmpeg`.
+/// Returns `None` if the home directory cannot be found.
 fn bundled_ffmpeg_base_dir() -> Option<PathBuf> {
     home::home_dir().map(|h| h.join("pankosmia").join("_assets").join("ffmpeg"))
 }
 
-/// Cherche récursivement le binaire ffmpeg téléchargé localement par l'app
-/// desktop dans `~/pankosmia/_assets/ffmpeg/**`. Renvoie son chemin absolu s'il
-/// existe. La recherche est récursive car selon l'OS/le build le binaire est
-/// niché dans un sous-dossier (ex. `.../7.1.1/bin/ffmpeg.exe` sur Windows).
+/// Recursively searches `~/pankosmia/_assets/ffmpeg/**` for the ffmpeg binary
+/// downloaded locally by the desktop app and returns its absolute path if
+/// present. The search is recursive because, depending on the OS/build, the
+/// binary is nested in a subdirectory (e.g. `.../7.1.1/bin/ffmpeg.exe` on
+/// Windows).
 pub(crate) fn find_bundled_ffmpeg() -> Option<String> {
     let base = bundled_ffmpeg_base_dir()?;
     if !base.is_dir() {

--- a/src/utils/ffmpeg.rs
+++ b/src/utils/ffmpeg.rs
@@ -1,0 +1,34 @@
+use std::env;
+use std::path::PathBuf;
+use walkdir::WalkDir;
+
+/// Nom de l'exécutable ffmpeg selon l'OS.
+fn ffmpeg_executable_name() -> &'static str {
+    match env::consts::OS {
+        "windows" => "ffmpeg.exe",
+        _ => "ffmpeg",
+    }
+}
+
+/// Dossier où l'app desktop télécharge ffmpeg : `~/pankosmia/_assets/ffmpeg`.
+/// Renvoie `None` si le home dir est introuvable.
+fn bundled_ffmpeg_base_dir() -> Option<PathBuf> {
+    home::home_dir().map(|h| h.join("pankosmia").join("_assets").join("ffmpeg"))
+}
+
+/// Cherche récursivement le binaire ffmpeg téléchargé localement par l'app
+/// desktop dans `~/pankosmia/_assets/ffmpeg/**`. Renvoie son chemin absolu s'il
+/// existe. La recherche est récursive car selon l'OS/le build le binaire est
+/// niché dans un sous-dossier (ex. `.../7.1.1/bin/ffmpeg.exe` sur Windows).
+pub(crate) fn find_bundled_ffmpeg() -> Option<String> {
+    let base = bundled_ffmpeg_base_dir()?;
+    if !base.is_dir() {
+        return None;
+    }
+    let exe = ffmpeg_executable_name();
+    WalkDir::new(&base)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_type().is_file() && e.file_name().to_str() == Some(exe))
+        .and_then(|e| e.path().to_str().map(str::to_string))
+}

--- a/src/utils/launch.rs
+++ b/src/utils/launch.rs
@@ -171,7 +171,8 @@ pub(crate) fn add_routes(rocket_instance: Rocket<Build>) -> Rocket<Build> {
         "/api/audio",
         routes![
             endpoints::audio::compile_audio::compile_audio,
-            endpoints::audio::compile_chapter_audio::compile_chapter_audio
+            endpoints::audio::compile_chapter_audio::compile_chapter_audio,
+            endpoints::audio::ffmpeg_path::ffmpeg_path
         ]
     )
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod json_responses;
 pub(crate) mod paths;
+pub(crate) mod ffmpeg;
 pub(crate) mod mime;
 pub(crate) mod client;
 pub(crate) mod files;


### PR DESCRIPTION
### Overview
Add a backend endpoint that resolves the FFmpeg binary bundled by the desktop app, so the client can pass its path to audio compilation requests and fall back to system FFmpeg when absent.

### Changes
- Add `GET /audio/ffmpeg-path`, returning `payload.path` to the locally downloaded FFmpeg (or `null` if none is found).
- Add a `find_bundled_ffmpeg` util that recursively searches `~/pankosmia/_assets/ffmpeg/**` for the OS-specific executable.